### PR TITLE
Normalise file paths

### DIFF
--- a/task/utils/azureDevOpsClient.ts
+++ b/task/utils/azureDevOpsClient.ts
@@ -141,7 +141,7 @@ export class AzureDevOpsClient {
               fs.writeFileSync(suggestion.path, Buffer.from(lines.join('\n')));
             }
           } catch (e) {
-            error(`Failed to patch local file with multiple suggestions: ${e}`);
+            throw new Error(`Failed to patch local file with multiple suggestions: ${e}`);
           }
         });
 
@@ -179,7 +179,7 @@ export class AzureDevOpsClient {
         this.project,
       );
     } catch (e) {
-      error(`Failed to commit codespell suggestions to pull request: ${e}`);
+      throw new Error(`Failed to commit codespell suggestions to pull request: ${e}`);
     }
   }
 
@@ -281,7 +281,7 @@ export class AzureDevOpsClient {
         );
       });
     } catch (e) {
-      error(`Failed to comment codespell suggestions on pull request: ${e}`);
+      throw new Error(`Failed to comment codespell suggestions on pull request: ${e}`);
     }
   }
 
@@ -323,7 +323,7 @@ export class AzureDevOpsClient {
         });
       });
     } catch (e) {
-      error(`Failed to process user commands in pull request: ${e}`);
+      throw new Error(`Failed to process user commands in pull request: ${e}`);
     }
   }
 

--- a/task/utils/codespellRunner.ts
+++ b/task/utils/codespellRunner.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { debug, error, tool, warning, which } from 'azure-pipelines-task-lib/task';
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 import { IFile, IFileSuggestion } from './types';
@@ -72,7 +74,7 @@ export class CodespellRunner {
           const fixedFileMatch = line.match(/FIXED\: (.*)/i);
           if (fixedFileMatch) {
             fixedFiles.push({
-              path: fixedFileMatch[1].trim(),
+              path: path.normalize(fixedFileMatch[1]).trim(),
             });
           }
           const warningMatch = line.match(/WARNING\: (.*)/i);
@@ -162,6 +164,7 @@ export class CodespellRunner {
           .split('\n')
           .map((p) => p.trim())
           .filter((p) => p.length > 0)
+          .map((p) => path.normalize(p))
       : [];
   }
 }


### PR DESCRIPTION
Normalise file paths.
Throw errors rather than just logging them to ensure the task fails on error.